### PR TITLE
Add a recent blog post popup

### DIFF
--- a/src/app/api/recent-post/route.ts
+++ b/src/app/api/recent-post/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit') ?? '1';
+
+  const baseUrl =
+    process.env.BLOG_API_URL ?? 'https://blog.wamphlett.net';
+
+  const res = await fetch(`${baseUrl}/recent?limit=${limit}`, {
+    next: { revalidate: 300 },
+  });
+
+  if (!res.ok) {
+    return NextResponse.json({ articles: [] }, { status: res.status });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Timeline from '@/components/timeline';
 import { getOrderedEventsFromConfig } from '@/app/config-events';
 import Introduction from '@/components/introduction';
 import More from '@/components/more';
+import RecentPostPopup from '@/components/recentPostPopup';
 import { getBlurUrl } from './loaders';
 
 export default async function Page() {
@@ -15,6 +16,7 @@ export default async function Page() {
     getOrderedEventsFromConfig(),
   ]);
   return (
+    <>
     <PrimaryLayout
       headerImageUrl={headerURL}
       headerImageBlurDataURL={blurDataURL ?? ''}
@@ -46,5 +48,7 @@ export default async function Page() {
         ]}
       />
     </PrimaryLayout>
+    <RecentPostPopup />
+    </>
   );
 }

--- a/src/components/recentPostPopup.module.css
+++ b/src/components/recentPostPopup.module.css
@@ -1,0 +1,125 @@
+@media (max-width: 640px) {
+  .popup {
+    display: none;
+  }
+}
+
+.popup {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  width: 320px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22), 0 4px 16px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 2s ease-out, transform 2s ease-out;
+  pointer-events: none;
+}
+
+.popup.visible {
+  opacity: 0.9;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition: opacity 2s ease-out, transform 2s ease-out;
+}
+
+.popup.visible:hover {
+  opacity: 1;
+  transition: opacity 0.3s ease-out;
+}
+
+.link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.imageWrapper {
+  position: relative;
+  width: 100%;
+  height: 176px;
+  overflow: hidden;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.link:hover .image {
+  transform: scale(1.04);
+}
+
+.body {
+  padding: 18px 20px 20px;
+}
+
+.label {
+  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+  margin: 0 0 6px;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #111;
+  line-height: 1.35;
+  margin: 0 0 8px;
+}
+
+.description {
+  font-size: 13px;
+  color: #666;
+  line-height: 1.55;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.readMore {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #6366f1;
+  text-decoration: none;
+}
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.45);
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1;
+  z-index: 10;
+  transition: background 0.2s;
+  padding: 0;
+}
+
+.close:hover {
+  background: rgba(0, 0, 0, 0.65);
+}

--- a/src/components/recentPostPopup.tsx
+++ b/src/components/recentPostPopup.tsx
@@ -1,0 +1,64 @@
+'use client';
+import React, { useState, useEffect } from 'react';
+import styles from './recentPostPopup.module.css';
+
+type Article = {
+  title: string;
+  topicSlug: string;
+  slug: string;
+  description: string;
+  image: string;
+  url: string;
+  publishedAt: number;
+};
+
+const THREE_MONTHS_MS = 3 * 30 * 24 * 60 * 60 * 1000;
+
+export default function RecentPostPopup() {
+  const [article, setArticle] = useState<Article | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/recent-post?limit=1`)
+      .then((r) => r.json())
+      .then((data) => {
+        const art: Article = data.articles?.[0];
+        if (!art) return;
+        const ageMs = Date.now() - art.publishedAt * 1000;
+        if (ageMs > THREE_MONTHS_MS) return;
+        setArticle(art);
+        setTimeout(() => setVisible(true), 2400);
+      })
+      .catch(() => {});
+  }, []);
+
+  if (!article || dismissed) return null;
+
+  const blogBaseUrl = process.env.NEXT_PUBLIC_BLOG_SITE_URL ?? 'https://blog.warrenamphlett.co.uk';
+  const href = `${blogBaseUrl}/${article.topicSlug}/${article.slug}`;
+
+  return (
+    <div className={`${styles.popup} ${visible ? styles.visible : ''}`}>
+      <button
+        className={styles.close}
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+      <a href={href} className={styles.link} target="_blank" rel="noopener noreferrer">
+        <div className={styles.imageWrapper}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={article.image} alt={article.title} className={styles.image} />
+        </div>
+        <div className={styles.body}>
+          <p className={styles.label}>Latest post</p>
+          <h3 className={styles.title}>{article.title}</h3>
+          <p className={styles.description}>{article.description}</p>
+          <span className={styles.readMore}>Read post →</span>
+        </div>
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a "Recent Post" popup feature to the homepage, which displays the latest blog post if it was published within the last three months. The implementation includes a new API route for fetching recent posts, a React client component for the popup, and associated styling. The popup is only shown on larger screens and can be dismissed by the user.

**Recent Post Popup Feature**

- **API Integration**
  - Added a new API route (`src/app/api/recent-post/route.ts`) that fetches recent blog posts from an external API, with a configurable limit and error handling.

- **UI Component**
  - Implemented the `RecentPostPopup` React component (`src/components/recentPostPopup.tsx`) that fetches the latest post, checks its age, and displays it in a styled popup. The popup appears with a delay, is dismissible, and only shows posts from the last three months.

- **Styling**
  - Added CSS module (`src/components/recentPostPopup.module.css`) to style the popup, including responsiveness (hidden on mobile), transitions, and hover effects.

- **Homepage Integration**
  - Imported and rendered the `RecentPostPopup` component in the homepage (`src/app/page.tsx`), ensuring it appears above the main layout and is only included once. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR8) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR19) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR51-R52)